### PR TITLE
Fix ssChain random selection range

### DIFF
--- a/awget.py
+++ b/awget.py
@@ -39,7 +39,7 @@ for ss in ssChain:
     print("<%s, %s>" % (ss[0], ss[1]))
 
 if (numSS >= 2):
-    choice = random.randrange(numSS - 1)
+    choice = random.randrange(numSS)
 else:
     choice = 0
 ssAddr = ssChain[choice]


### PR DESCRIPTION
The -1 is unnecessary here, right? I think randrange cannot return the value passed into it, so randrange(2) will return either 0 or 1.